### PR TITLE
Fix handling of timeseries with 0 to 3 points in Vectorization

### DIFF
--- a/chronix-server-query-handler/src/main/java/de/qaware/chronix/solr/query/analysis/functions/transformation/Vectorization.java
+++ b/chronix-server-query-handler/src/main/java/de/qaware/chronix/solr/query/analysis/functions/transformation/Vectorization.java
@@ -42,8 +42,12 @@ public class Vectorization implements ChronixTransformation<MetricTimeSeries> {
     @Override
     public MetricTimeSeries transform(MetricTimeSeries timeSeries) {
 
-
         int size = timeSeries.size();
+        //do not simplify if there are insufficient data points
+        if(size <= 3) {
+            return timeSeries;
+        }
+
         byte[] use_point = new byte[size];
 
         long[] rawTimeStamps = timeSeries.getTimestampsAsArray();
@@ -89,11 +93,6 @@ public class Vectorization implements ChronixTransformation<MetricTimeSeries> {
 
     private void compute(long[] timestamps, double[] values, byte[] use_point, float tolerance) {
 
-        // do not simplify if not at least 3 points are available
-        if (timestamps.length == 3) {
-            return;
-        }
-
         int ix_a = 0;
         int ix_b = 1;
         use_point[ix_a] = 1;
@@ -104,7 +103,6 @@ public class Vectorization implements ChronixTransformation<MetricTimeSeries> {
                 use_point[i - 1] = 0;
                 use_point[i] = 1;
             } else {
-
                 // do not continue if not at least one more point is available
                 if (i + 1 >= timestamps.length) {
                     for (int j = i; j < timestamps.length; j++) {
@@ -112,7 +110,6 @@ public class Vectorization implements ChronixTransformation<MetricTimeSeries> {
                     }
                     return;
                 }
-
                 ix_a = i;
                 ix_b = i + 1;
                 use_point[ix_a] = 1;

--- a/chronix-server-query-handler/src/test/groovy/de/qaware/chronix/solr/query/analysis/functions/transformation/VectorizationTest.groovy
+++ b/chronix-server-query-handler/src/test/groovy/de/qaware/chronix/solr/query/analysis/functions/transformation/VectorizationTest.groovy
@@ -17,6 +17,7 @@ package de.qaware.chronix.solr.query.analysis.functions.transformation
 
 import de.qaware.chronix.solr.query.analysis.functions.FunctionType
 import de.qaware.chronix.timeseries.MetricTimeSeries
+import spock.lang.Shared
 import spock.lang.Specification
 
 import java.time.Instant
@@ -28,22 +29,66 @@ import java.time.temporal.ChronoUnit
  */
 class VectorizationTest extends Specification {
 
+    @Shared
+    def vectorization = new Vectorization()
+
     def "test transform"() {
         given:
         def timeSeriesBuilder = new MetricTimeSeries.Builder("Vector")
+
         def now = Instant.now()
 
         100.times {
             timeSeriesBuilder.point(now.plus(it, ChronoUnit.SECONDS).toEpochMilli(), it + 1)
         }
 
-        def vectorization = new Vectorization();
-
         when:
         def vectorizedTimeSeries = vectorization.transform(timeSeriesBuilder.build())
 
         then:
         vectorizedTimeSeries.size() == 2
+    }
+
+    def "test transform - 0 points"() {
+        given:
+        def timeSeriesBuilder = new MetricTimeSeries.Builder("Vector")
+
+        when:
+        def vectorizedTimeSeries = vectorization.transform(timeSeriesBuilder.build())
+
+        then:
+        vectorizedTimeSeries.size() == 0
+    }
+
+    def "test transform - 1..3 Points"() {
+        given:
+        def timeSeriesBuilder1 = new MetricTimeSeries.Builder("Vector")
+        def timeSeriesBuilder2 = new MetricTimeSeries.Builder("Vector")
+        def timeSeriesBuilder3 = new MetricTimeSeries.Builder("Vector")
+
+        def now = Instant.now()
+
+        when:
+        1.times {
+            timeSeriesBuilder1.point(now.plus(it, ChronoUnit.SECONDS).toEpochMilli(), it + 1)
+        }
+
+        2.times {
+            timeSeriesBuilder2.point(now.plus(it, ChronoUnit.SECONDS).toEpochMilli(), it + 1)
+        }
+
+        3.times {
+            timeSeriesBuilder3.point(now.plus(it, ChronoUnit.SECONDS).toEpochMilli(), it + 1)
+        }
+
+        def vectorized1 = vectorization.transform(timeSeriesBuilder1.build())
+        def vectorized2 = vectorization.transform(timeSeriesBuilder2.build())
+        def vectorized3 = vectorization.transform(timeSeriesBuilder3.build())
+
+        then:
+        vectorized1.size() == 1
+        vectorized2.size() == 2
+        vectorized3.size() == 3
     }
 
     def "test type"() {


### PR DESCRIPTION
- Fix ArrayOutOfBoundsException when a timeseries has 0/1 points (happened in line 100)
- If a timeseries has only 0..3 points, previously an empty timeseries has been returned (since use_point only contains 0´s). Now in such a case the original timeseries will be returned.
- refactored Vectorization.compute() method (pre initialize use_point array, remove unneeded for-loops, reduce nesting)
- add method overload for transform with additional tolerance argument