### PR TITLE
Use the Gradle wrapper for leaner requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -346,10 +346,9 @@ your improvements, to the Chronix projects. All you have to do is to fork this r
 improve the code and issue a pull request.
 
 ## Building Chronix from Scratch
-Everything should run out of the box. The only three things that must be available:
+Everything should run out of the box. The only two things that must be available:
 - Git
 - JDK 1.8
-- Gradle
 
 Just do the following steps:
 
@@ -357,7 +356,7 @@ Just do the following steps:
 cd <checkout-dir>
 git clone https://github.com/ChronixDB/chronix.server.git
 cd chronix.server
-gradle clean build
+./gradlew clean build
 ```
 
 ## Maintainer


### PR DESCRIPTION
There is no need to have a requirement on Gradle if one uses the
Gradle wrapper for building. In addition this makes sure the correct
Gradle version is used.